### PR TITLE
Lazy Context Propagation & useContextSelector hook

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -190,6 +190,10 @@ export type Fiber = {|
   // This is used to quickly determine if a subtree has no pending changes.
   childExpirationTime: ExpirationTime,
 
+  // an identifier that allows the context propagation algorithm to determine
+  // if this fiber has been visited during a previous propagation
+  propagationSigil: any,
+
   // This is a pooled version of a Fiber. Every fiber that gets updated will
   // eventually have a pair. There are cases when we can clean up pairs to save
   // memory if we need to.
@@ -274,6 +278,8 @@ function FiberNode(
 
   this.expirationTime = NoWork;
   this.childExpirationTime = NoWork;
+
+  this.propagationSigil = null;
 
   this.alternate = null;
 
@@ -425,6 +431,7 @@ export function createWorkInProgress(
 
   workInProgress.childExpirationTime = current.childExpirationTime;
   workInProgress.expirationTime = current.expirationTime;
+  workInProgress.propagationSigil = current.propagationSigil;
 
   workInProgress.child = current.child;
   workInProgress.memoizedProps = current.memoizedProps;
@@ -803,6 +810,7 @@ export function assignFiberPropertiesInDEV(
   target.lastEffect = source.lastEffect;
   target.expirationTime = source.expirationTime;
   target.childExpirationTime = source.childExpirationTime;
+  target.propagationSigil = source.propagationSigil;
   target.alternate = source.alternate;
   if (enableProfilerTimer) {
     target.actualDuration = source.actualDuration;

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1049,6 +1049,142 @@ describe('ReactNewContext', () => {
           span(2),
         ]);
       });
+      describe('stress test', () => {
+        it('controlled lots of contexts', () => {
+          let ContextA = React.createContext(0);
+          let ConsumerA = getConsumer(ContextA);
+
+          let ContextB = React.createContext(0);
+          let ConsumerB = getConsumer(ContextB);
+
+          let ContextC = React.createContext(0);
+          let ConsumerC = getConsumer(ContextC);
+
+          class Indirection extends React.Component {
+            shouldComponentUpdate() {
+              return false;
+            }
+            render() {
+              return this.props.children;
+            }
+          }
+
+          const Foo = React.memo(({consumer, depth, name, children}) => {
+            let Consumer = consumer;
+
+            if (typeof depth !== 'number' || depth <= 1) {
+              return (
+                <Consumer>
+                  {value => <Yield name={name} value={value} />}
+                </Consumer>
+              );
+            } else {
+              return (
+                <Indirection>
+                  <Consumer>
+                    {_ => (
+                      <Foo name={name} consumer={consumer} depth={depth - 1}>
+                        {children}
+                      </Foo>
+                    )}
+                  </Consumer>
+                </Indirection>
+              );
+            }
+          });
+
+          const Yield = ({name, value}) => {
+            let output = `${name}: ${value}`;
+            Scheduler.yieldValue(output);
+            return <span>{output}</span>;
+          };
+
+          function App(props) {
+            return (
+              <ContextA.Provider value={props.a}>
+                <ContextB.Provider value={props.b}>
+                  <ContextC.Provider value={props.c}>
+                    <Foo name="A" consumer={ConsumerA} depth={props.depth} />
+                    <Foo name="B" consumer={ConsumerB} depth={props.depth} />
+                    <Foo name="C" consumer={ConsumerC} depth={props.depth} />
+                  </ContextC.Provider>
+                </ContextB.Provider>
+              </ContextA.Provider>
+            );
+          }
+
+          for (let i = 0; i < 25; i++) {
+            // each individually
+            ReactNoop.render(<App a={0} b={0} c={0} depth={10} />);
+            expect(Scheduler).toFlushAndYield(['A: 0', 'B: 0', 'C: 0']);
+            ReactNoop.render(<App a={1} b={0} c={0} depth={20} />);
+            expect(Scheduler).toFlushAndYield(['A: 1']);
+            ReactNoop.render(<App a={1} b={1} c={0} depth={30} />);
+            expect(Scheduler).toFlushAndYield(['B: 1']);
+            ReactNoop.render(<App a={1} b={1} c={1} depth={40} />);
+            expect(Scheduler).toFlushAndYield(['C: 1']);
+            // two at a time
+            ReactNoop.render(<App a={2} b={2} c={1} depth={50} />);
+            expect(Scheduler).toFlushAndYield(['A: 2', 'B: 2']);
+            ReactNoop.render(<App a={2} b={3} c={3} depth={40} />);
+            expect(Scheduler).toFlushAndYield(['B: 3', 'C: 3']);
+            // all at once
+            ReactNoop.render(<App a={4} b={4} c={4} depth={30} />);
+            expect(Scheduler).toFlushAndYield(['A: 4', 'B: 4', 'C: 4']);
+          }
+        });
+        it('non-context stress test', () => {
+          const Foo = React.memo(({depth, name, children}) => {
+            if (typeof depth !== 'number' || depth <= 1) {
+              return <Yield name={name} />;
+            } else {
+              return (
+                <Foo name={name} depth={depth - 1}>
+                  {children}
+                </Foo>
+              );
+            }
+          });
+
+          const Yield = ({name}) => {
+            let output = `${name}`;
+            Scheduler.yieldValue(output);
+            return <span>{output}</span>;
+          };
+
+          function App(props) {
+            return (
+              <div>
+                <Foo name="A" depth={props.depth} />
+                <Foo name="B" depth={props.depth} />
+                <Foo name="C" depth={props.depth} />
+              </div>
+            );
+          }
+
+          for (let i = 0; i < 50; i++) {
+            // each individually
+            ReactNoop.render(<App depth={10} />);
+            expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+            ReactNoop.render(<App depth={20} />);
+            expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+            ReactNoop.render(<App depth={30} />);
+            expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+            ReactNoop.render(<App depth={15} />);
+            expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+            ReactNoop.render(<App depth={100} />);
+            expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+            ReactNoop.render(<App depth={64} />);
+            expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+            ReactNoop.render(<App depth={37} />);
+            expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+            ReactNoop.render(<App depth={48} />);
+            expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+            ReactNoop.render(<App depth={12} />);
+            expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+          }
+        });
+      });
     });
   }
 

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -31,6 +31,7 @@ import memo from './memo';
 import {
   useCallback,
   useContext,
+  useContextSelector,
   useEffect,
   useImperativeHandle,
   useDebugValue,
@@ -75,6 +76,7 @@ const React = {
 
   useCallback,
   useContext,
+  useContextSelector,
   useEffect,
   useImperativeHandle,
   useDebugValue,

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -42,6 +42,7 @@ export function createContext<T>(
     // Secondary renderers store their context values on separate fields.
     _currentValue: defaultValue,
     _currentValue2: defaultValue,
+    _currentChangedBits: 0,
     // Used to track how many concurrent renderers this context currently
     // supports within in a single renderer. Such as parallel server rendering.
     _threadCount: 0,

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -69,6 +69,35 @@ export function useContext<T>(
   return dispatcher.useContext(Context, unstable_observedBits);
 }
 
+export function useContextSelector<T, S>(
+  Context: ReactContext<T>,
+  selector: T => S,
+) {
+  const dispatcher = resolveDispatcher();
+  if (__DEV__) {
+    // TODO: add a more generic warning for invalid values.
+    if ((Context: any)._context !== undefined) {
+      const realContext = (Context: any)._context;
+      // Don't deduplicate because this legitimately causes bugs
+      // and nobody should be using this in existing code.
+      if (realContext.Consumer === Context) {
+        warning(
+          false,
+          'Calling useContextSelector(Context.Consumer, selector) is not supported, may cause bugs, and will be ' +
+            'removed in a future major release. Did you mean to call useContextSelector(Context, selector) instead?',
+        );
+      } else if (realContext.Provider === Context) {
+        warning(
+          false,
+          'Calling useContext(Context.Provider, selector) is not supported. ' +
+            'Did you mean to call useContext(Contextm, selector) instead?',
+        );
+      }
+    }
+  }
+  return dispatcher.useContextSelector(Context, selector);
+}
+
 export function useState<S>(initialState: (() => S) | S) {
   const dispatcher = resolveDispatcher();
   return dispatcher.useState(initialState);

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -75,3 +75,6 @@ export const revertPassiveEffectsChange = false;
 // but without making them discrete. The flag exists in case it causes
 // starvation problems.
 export const enableUserBlockingEvents = false;
+
+// Alternate Context Propagation algorithm, variation that propagates all contexts together
+export const enableLazyContextPropagation = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -36,6 +36,7 @@ export const enableJSXTransformAPI = false;
 export const warnAboutMissingMockScheduler = true;
 export const revertPassiveEffectsChange = false;
 export const enableUserBlockingEvents = false;
+export const enableLazyContextPropagation = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -31,6 +31,7 @@ export const enableJSXTransformAPI = false;
 export const warnAboutMissingMockScheduler = false;
 export const revertPassiveEffectsChange = false;
 export const enableUserBlockingEvents = false;
+export const enableLazyContextPropagation = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -31,6 +31,7 @@ export const enableJSXTransformAPI = false;
 export const warnAboutMissingMockScheduler = true;
 export const revertPassiveEffectsChange = false;
 export const enableUserBlockingEvents = false;
+export const enableLazyContextPropagation = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -31,6 +31,7 @@ export const enableJSXTransformAPI = false;
 export const warnAboutMissingMockScheduler = false;
 export const revertPassiveEffectsChange = false;
 export const enableUserBlockingEvents = false;
+export const enableLazyContextPropagation = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -31,6 +31,7 @@ export const enableEventAPI = true;
 export const enableJSXTransformAPI = true;
 export const warnAboutMissingMockScheduler = true;
 export const enableUserBlockingEvents = false;
+export const enableLazyContextPropagation = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -21,6 +21,7 @@ export const {
   warnAboutDeprecatedSetNativeProps,
   revertPassiveEffectsChange,
   enableUserBlockingEvents,
+  enableLazyContextPropagation,
 } = require('ReactFeatureFlags');
 
 // In www, we have experimental support for gathering data


### PR DESCRIPTION
Will end up breaking into separate RFCs and PRs

For now

Lazy Propagation Algorithm: attempts to take advantage of already scheduled work to avoid walking the fiber tree except when necessary (on bailouts that don't go deeper for work on children)

useContextSelector hook: adds a hook that is a modified context reader. it will only schedule work on it's host fiber when the selector value has changed. This hook is intended to be used with the new propagation scheme because it otherwise has numerous problems with selectors running too often / too early.